### PR TITLE
[feat] 주문 API 개발 고급 - 지연 로딩과 조회 성능 최적화

### DIFF
--- a/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,13 +1,19 @@
 package jpabook.jpashop.api;
 
+import jpabook.jpashop.domain.Address;
 import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.repository.OrderSearch;
+import jpabook.jpashop.repository.OrderSimpleQueryDto;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * xToOne(ManyToOne, OneToOne)
@@ -22,9 +28,54 @@ public class OrderSimpleApiController {
 
     private final OrderRepository orderRepository;
 
-    @GetMapping("/api/v1/simple-orders")
-    public List<Order> ordersV1() {
-        List<Order> all = orderRepository.findAllByString(new OrderSearch());
-        return all;
+//    @GetMapping("/api/v1/simple-orders")
+//    public List<Order> ordersV1() {
+//        List<Order> all = orderRepository.findAllByString(new OrderSearch());
+//        return all;
+//    }
+
+    @GetMapping("/api/v2/simple-orders")
+    public List<SimpleOrderDto> ordersV2() {
+        List<Order> orders = orderRepository.findAllByString(new OrderSearch());
+        List<SimpleOrderDto> result = orders.stream()
+                .map(o -> new SimpleOrderDto(o))
+                .collect(Collectors.toList());
+
+        return result;
     }
+
+    @GetMapping("/api/v3/simple-orders")
+    public List<SimpleOrderDto> ordersV3() {
+        List<Order> orders = orderRepository.findAllWithMemberDelivery();
+        List<SimpleOrderDto> result = orders.stream()
+                .map(o -> new SimpleOrderDto(o))
+                .collect(Collectors.toList());
+
+        return result;
+    }
+
+    @GetMapping("/api/v4/simple-orders")
+    public List<OrderSimpleQueryDto> ordersV4() {
+        return orderRepository.findOrderDtos();
+    }
+
+
+
+    @Data
+    static class SimpleOrderDto {
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private OrderStatus orderStatus;
+        private Address address;
+
+        public SimpleOrderDto(Order order) {
+            orderId = order.getId();
+            name = order.getMember().getName();
+            orderDate = order.getOrderDate();
+            orderStatus = order.getStatus();
+            address = order.getDelivery().getAddress();
+        }
+    }
+
 }

--- a/src/main/java/jpabook/jpashop/domain/Delivery.java
+++ b/src/main/java/jpabook/jpashop/domain/Delivery.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,6 +15,7 @@ public class Delivery {
     @Column(name = "delivery_id")
     private Long id;
 
+    @JsonIgnore
     @OneToOne(mappedBy = "delivery", fetch = LAZY)
     private Order order;
 

--- a/src/main/java/jpabook/jpashop/domain/Member.java
+++ b/src/main/java/jpabook/jpashop/domain/Member.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
@@ -22,6 +23,7 @@ public class Member {
     @Embedded
     private Address address;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<Order> orders = new ArrayList<>();
 }

--- a/src/main/java/jpabook/jpashop/domain/OrderItem.java
+++ b/src/main/java/jpabook/jpashop/domain/OrderItem.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jpabook.jpashop.domain.item.Item;
 import lombok.AccessLevel;
@@ -22,6 +23,7 @@ public class OrderItem {
     @JoinColumn(name = "item_id")
     private Item item;
 
+    @JsonIgnore
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "order_id")
     private Order order;

--- a/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -93,4 +93,20 @@ public class OrderRepository {
         return query.getResultList();
     }
 
+    public List<Order> findAllWithMemberDelivery() {
+        return em.createQuery(
+                "select o from Order o" +
+                        " join fetch o.member m" +
+                        " join fetch o.delivery d", Order.class
+        ).getResultList();
+    }
+
+    public List<OrderSimpleQueryDto> findOrderDtos() {
+        return em.createQuery("select new jpabook.jpashop.repository.OrderSimpleQueryDto(o.id, m.name, o.orderDate, o.status, d.address) " +
+                    "from Order o" +
+                    " join o.member m" +
+                    " join o.delivery d", OrderSimpleQueryDto.class
+                )
+                .getResultList();
+    }
 }

--- a/src/main/java/jpabook/jpashop/repository/OrderSimpleQueryDto.java
+++ b/src/main/java/jpabook/jpashop/repository/OrderSimpleQueryDto.java
@@ -1,0 +1,25 @@
+package jpabook.jpashop.repository;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class OrderSimpleQueryDto {
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+
+    public OrderSimpleQueryDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+    }
+}


### PR DESCRIPTION
### 구현
- 간단한 주문 조회 v1 - 엔티티를 직접 노출
=> 무한 조회 및 다양한 많은 설정 필수..

- 간단한 주문 조회 v2 - 엔티티를 DTO로 변환
=> N+1 문제 발생

- 간단한 주문 조회 v3 - 엔티티를 DTO로 변환 - 페치 조인 최적화

- 간단한 주문 조회 v4 - JPA에서 DTO로 바로 조


### 쿼리 방식 선택 권장 순서
1. 우선 엔티티를  DTO로 변환하는 방법을 선택
2. 필요하면 페치 조인으로 성능을 최적화 한다. => 대부분의 성능 이슈가 해결된다.
3. 그래도 안되면 DTO로 직접 조회하는 방법을 사용하낟.
4. 최후의 방법은 JPA가 제공하는 네이티브 SQL이나 스프링 JDBC Template을 사용해서 SQL을 직접 사용한다.